### PR TITLE
Merged PR 1576: update version to 1.0.1

### DIFF
--- a/Common/version.props
+++ b/Common/version.props
@@ -1,7 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 </div>
 
 [![NuGet](https://img.shields.io/nuget/v/Microsoft.Coyote.svg)](https://www.nuget.org/packages/Microsoft.Coyote/)
-[![Build status](https://dev.azure.com/foundry99/Coyote/_apis/build/status/Coyote-Windows-CI)](https://dev.azure.com/foundry99/Coyote/_build/latest?definitionId=49) [![Join the chat at https://gitter.im/Microsoft/coyote](https://badges.gitter.im/Microsoft/coyote.svg)](https://gitter.im/Microsoft/coyote?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build status](https://dev.azure.com/foundry99/Coyote/_apis/build/status/Coyote-Windows-CI)](https://dev.azure.com/foundry99/Coyote/_build/latest?definitionId=49)
+[![Join the chat at https://gitter.im/Microsoft/coyote](https://badges.gitter.im/Microsoft/coyote.svg)](https://gitter.im/Microsoft/coyote?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Coyote is a programming framework for building reliable asynchronous software. Coyote ensures design
 and code remain in sync, dramatically simplifying the addition of new features. Coyote comes with

--- a/Source/Core/Actors/RuntimeFactory.cs
+++ b/Source/Core/Actors/RuntimeFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Coyote.Actors
             }
 
             var valueGenerator = new RandomValueGenerator(configuration);
-            var runtime = new ActorRuntime(configuration ?? Configuration.Create(), valueGenerator);
+            var runtime = new ActorRuntime(configuration, valueGenerator);
 
             // Assign the runtime to the currently executing asynchronous control flow.
             CoyoteRuntime.AssignAsyncControlFlowRuntime(runtime);

--- a/Source/Core/Runtime/RuntimeFactory.cs
+++ b/Source/Core/Runtime/RuntimeFactory.cs
@@ -11,13 +11,24 @@ namespace Microsoft.Coyote.Runtime
     public static class RuntimeFactory
     {
         /// <summary>
+        /// The installed runtime instance.
+        /// </summary>
+        internal static CoyoteRuntime InstalledRuntime { get; private set; } = CreateWithConfiguration(default);
+
+        /// <summary>
+        /// Protects access to the installed runtime.
+        /// </summary>
+        private static readonly object SyncObject = new object();
+
+        /// <summary>
         /// Creates a new Coyote runtime.
         /// </summary>
         /// <returns>The created task runtime.</returns>
         /// <remarks>
-        /// Only one runtime can be created per async local context. This is not a thread-safe operation.
+        /// Only one task runtime can be created per process. If you create a new task
+        /// runtime it replaces the previously installed one.
         /// </remarks>
-        public static ICoyoteRuntime Create() => Create(default);
+        public static ICoyoteRuntime Create() => CreateAndInstall(default);
 
         /// <summary>
         /// Creates a new Coyote runtime with the specified <see cref="Configuration"/>.
@@ -25,9 +36,28 @@ namespace Microsoft.Coyote.Runtime
         /// <param name="configuration">The runtime configuration to use.</param>
         /// <returns>The created task runtime.</returns>
         /// <remarks>
-        /// Only one runtime can be created per async local context. This is not a thread-safe operation.
+        /// Only one task runtime can be created per process. If you create a new task
+        /// runtime it replaces the previously installed one.
         /// </remarks>
-        public static ICoyoteRuntime Create(Configuration configuration)
+        public static ICoyoteRuntime Create(Configuration configuration) => CreateAndInstall(configuration);
+
+        /// <summary>
+        /// Creates a new Coyote runtime with the specified <see cref="Configuration"/> and sets
+        /// it as the installed runtime, or returns the installed runtime if it already exists.
+        /// </summary>
+        private static CoyoteRuntime CreateAndInstall(Configuration configuration)
+        {
+            lock (SyncObject)
+            {
+                // Assign the newly created runtime as the installed runtime.
+                return InstalledRuntime = CreateWithConfiguration(configuration);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Coyote runtime with the specified <see cref="Configuration"/>.
+        /// </summary>
+        private static CoyoteRuntime CreateWithConfiguration(Configuration configuration)
         {
             if (configuration is null)
             {
@@ -35,11 +65,7 @@ namespace Microsoft.Coyote.Runtime
             }
 
             var valueGenerator = new RandomValueGenerator(configuration);
-            var runtime = new ActorRuntime(configuration ?? Configuration.Create(), valueGenerator);
-
-            // Assign the runtime to the currently executing asynchronous control flow.
-            CoyoteRuntime.AssignGlobalRuntime(runtime);
-            return runtime;
+            return new ActorRuntime(configuration, valueGenerator);
         }
     }
 }

--- a/Source/Core/SystematicTesting/TestingEngine.cs
+++ b/Source/Core/SystematicTesting/TestingEngine.cs
@@ -506,11 +506,6 @@ namespace Microsoft.Coyote.SystematicTesting
                         $"triggered bug #{this.TestReport.NumOfFoundBugs} " +
                         $"[task-{this.Configuration.TestingProcessId}]");
                 }
-                else if (this.Strategy.HasReachedMaxSchedulingSteps())
-                {
-                    this.Logger.WriteLine($"..... Iteration #{iteration + 1} " +
-                        $"exceeded max-steps [task-{this.Configuration.TestingProcessId}]");
-                }
 
                 // Cleans up the runtime before the next iteration starts.
                 runtimeLogger?.Dispose();

--- a/docs/_learn/ref/Microsoft.Coyote.Runtime/RuntimeFactory/Create.md
+++ b/docs/_learn/ref/Microsoft.Coyote.Runtime/RuntimeFactory/Create.md
@@ -18,7 +18,7 @@ The created task runtime.
 
 ## Remarks
 
-Only one runtime can be created per async local context. This is not a thread-safe operation.
+Only one task runtime can be created per process. If you create a new task runtime it replaces the previously installed one.
 
 ## See Also
 
@@ -47,7 +47,7 @@ The created task runtime.
 
 ## Remarks
 
-Only one runtime can be created per async local context. This is not a thread-safe operation.
+Only one task runtime can be created per process. If you create a new task runtime it replaces the previously installed one.
 
 ## See Also
 


### PR DESCRIPTION
This PR fixes an issue in the runtime and updates the version to 1.0.1.

Basically, there should always be a default task runtime instance (for cases were the user does not create a task runtime in production). The `Current` runtime should make sure to check if the runtime is controlled or not, as the behavior changes in testing. Also removed dead code in the runtime factories, fixed a remark and protecting the assignment of the installed task runtime using a lock.

Related work items: #2815, #2822