### PR TITLE
Code clean-up and re-use reference

### DIFF
--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Coyote
         {
             set
             {
-                this.MaxUnfairSchedulingSteps = value;
-                this.MaxFairSchedulingSteps = value;
+                this.MaxUnfairSchedulingSteps = this.MaxFairSchedulingSteps = value;
             }
         }
 
@@ -312,13 +311,9 @@ namespace Microsoft.Coyote
         protected Configuration()
         {
             this.OutputFilePath = string.Empty;
-
-            this.Timeout = 0;
-            this.RuntimeGeneration = 0;
-
+            this.Timeout = this.RuntimeGeneration = this.ParallelBugFindingTasks= this.TestingProcessId = this.StrategyBound = this.SafetyPrefixBound = this.LivenessTemperatureThreshold =  0;
             this.AssemblyToBeAnalyzed = string.Empty;
             this.TestMethodName = string.Empty;
-
             this.SchedulingStrategy = "random";
             this.TestingIterations = 1;
             this.RandomGeneratorSeed = null;
@@ -327,33 +322,23 @@ namespace Microsoft.Coyote
             this.MaxFairSchedulingSteps = 100000; // 10 times the unfair steps
             this.MaxUnfairSchedulingSteps = 10000;
             this.UserExplicitlySetMaxFairSchedulingSteps = false;
-            this.ParallelBugFindingTasks = 0;
             this.ParallelDebug = false;
             this.RunAsParallelBugFindingTask = false;
             this.TestingSchedulerEndPoint = "CoyoteTestScheduler.4723bb92-c413-4ecb-8e8a-22eb2ba22234";
             this.TestingSchedulerIpAddress = null;
-            this.TestingProcessId = 0;
             this.ConsiderDepthBoundHitAsBug = false;
-            this.StrategyBound = 0;
-            this.TimeoutDelay = 10;
-            this.SafetyPrefixBound = 0;
-
+            this.TimeoutDelay = 10;  
             this.IsLivenessCheckingEnabled = true;
-            this.LivenessTemperatureThreshold = 0;
             this.IsProgramStateHashingEnabled = false;
             this.IsMonitoringEnabledInInProduction = false;
             this.AttachDebugger = false;
-
             this.ScheduleFile = string.Empty;
             this.ScheduleTrace = string.Empty;
-
             this.ReportCodeCoverage = false;
             this.ReportActivityCoverage = false;
             this.DebugActivityCoverage = false;
-
             this.IsVerbose = false;
             this.EnableDebugging = false;
-
             this.AdditionalCodeCoverageAssemblies = new Dictionary<string, bool>();
 
             this.EnableColoredConsoleOutput = false;

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -317,31 +317,17 @@ namespace Microsoft.Coyote
             this.SchedulingStrategy = "random";
             this.TestingIterations = 1;
             this.RandomGeneratorSeed = null;
-            this.IncrementalSchedulingSeed = false;
-            this.PerformFullExploration = false;
+            this.IncrementalSchedulingSeed = this.PerformFullExploration  = this.UserExplicitlySetMaxFairSchedulingSteps = this.ParallelDebug = this.ConsiderDepthBoundHitAsBug = this.IsProgramStateHashingEnabled =  this.DebugActivityCoverage = this.IsVerbose = this.EnableDebugging = this.EnableColoredConsoleOutput = false;
             this.MaxFairSchedulingSteps = 100000; // 10 times the unfair steps
             this.MaxUnfairSchedulingSteps = 10000;
-            this.UserExplicitlySetMaxFairSchedulingSteps = false;
-            this.ParallelDebug = false;
-            this.RunAsParallelBugFindingTask = false;
+            this.RunAsParallelBugFindingTask = this.IsMonitoringEnabledInInProduction = this.AttachDebugger = this.ReportCodeCoverage = this.ReportActivityCoverage =  false;
             this.TestingSchedulerEndPoint = "CoyoteTestScheduler.4723bb92-c413-4ecb-8e8a-22eb2ba22234";
             this.TestingSchedulerIpAddress = null;
-            this.ConsiderDepthBoundHitAsBug = false;
             this.TimeoutDelay = 10;  
             this.IsLivenessCheckingEnabled = true;
-            this.IsProgramStateHashingEnabled = false;
-            this.IsMonitoringEnabledInInProduction = false;
-            this.AttachDebugger = false;
             this.ScheduleFile = string.Empty;
             this.ScheduleTrace = string.Empty;
-            this.ReportCodeCoverage = false;
-            this.ReportActivityCoverage = false;
-            this.DebugActivityCoverage = false;
-            this.IsVerbose = false;
-            this.EnableDebugging = false;
             this.AdditionalCodeCoverageAssemblies = new Dictionary<string, bool>();
-
-            this.EnableColoredConsoleOutput = false;
             this.DisableEnvironmentExit = true;
         }
 

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -316,14 +316,13 @@ namespace Microsoft.Coyote
             this.TestingIterations = 1;
             this.RandomGeneratorSeed = this.TestingSchedulerIpAddress = null;
             this.IncrementalSchedulingSeed = this.PerformFullExploration  = this.UserExplicitlySetMaxFairSchedulingSteps = this.ParallelDebug = this.ConsiderDepthBoundHitAsBug = this.IsProgramStateHashingEnabled =  this.DebugActivityCoverage = this.IsVerbose = this.EnableDebugging = this.EnableColoredConsoleOutput = false;
-            this.MaxFairSchedulingSteps = 100000; // 10 times the unfair steps
             this.MaxUnfairSchedulingSteps = 10000;
+            this.MaxFairSchedulingSteps = this.MaxUnfairSchedulingSteps * 10;
             this.RunAsParallelBugFindingTask = this.IsMonitoringEnabledInInProduction = this.AttachDebugger = this.ReportCodeCoverage = this.ReportActivityCoverage =  false;
             this.TestingSchedulerEndPoint = "CoyoteTestScheduler.4723bb92-c413-4ecb-8e8a-22eb2ba22234";
             this.TimeoutDelay = 10;  
-            this.IsLivenessCheckingEnabled = true;
+            this.IsLivenessCheckingEnabled = this.DisableEnvironmentExit = true;
             this.AdditionalCodeCoverageAssemblies = new Dictionary<string, bool>();
-            this.DisableEnvironmentExit = true;
         }
 
         /// <summary>

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -316,13 +316,12 @@ namespace Microsoft.Coyote
             this.TestMethodName = string.Empty;
             this.SchedulingStrategy = "random";
             this.TestingIterations = 1;
-            this.RandomGeneratorSeed = null;
+            this.RandomGeneratorSeed = this.TestingSchedulerIpAddress = null;
             this.IncrementalSchedulingSeed = this.PerformFullExploration  = this.UserExplicitlySetMaxFairSchedulingSteps = this.ParallelDebug = this.ConsiderDepthBoundHitAsBug = this.IsProgramStateHashingEnabled =  this.DebugActivityCoverage = this.IsVerbose = this.EnableDebugging = this.EnableColoredConsoleOutput = false;
             this.MaxFairSchedulingSteps = 100000; // 10 times the unfair steps
             this.MaxUnfairSchedulingSteps = 10000;
             this.RunAsParallelBugFindingTask = this.IsMonitoringEnabledInInProduction = this.AttachDebugger = this.ReportCodeCoverage = this.ReportActivityCoverage =  false;
             this.TestingSchedulerEndPoint = "CoyoteTestScheduler.4723bb92-c413-4ecb-8e8a-22eb2ba22234";
-            this.TestingSchedulerIpAddress = null;
             this.TimeoutDelay = 10;  
             this.IsLivenessCheckingEnabled = true;
             this.ScheduleFile = string.Empty;

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -310,10 +310,8 @@ namespace Microsoft.Coyote
         /// </summary>
         protected Configuration()
         {
-            this.OutputFilePath = string.Empty;
             this.Timeout = this.RuntimeGeneration = this.ParallelBugFindingTasks= this.TestingProcessId = this.StrategyBound = this.SafetyPrefixBound = this.LivenessTemperatureThreshold =  0;
-            this.AssemblyToBeAnalyzed = string.Empty;
-            this.TestMethodName = string.Empty;
+            this.OutputFilePath = this.AssemblyToBeAnalyzed = this.TestMethodName = this.ScheduleFile = this.ScheduleTrace = string.Empty;
             this.SchedulingStrategy = "random";
             this.TestingIterations = 1;
             this.RandomGeneratorSeed = this.TestingSchedulerIpAddress = null;
@@ -324,8 +322,6 @@ namespace Microsoft.Coyote
             this.TestingSchedulerEndPoint = "CoyoteTestScheduler.4723bb92-c413-4ecb-8e8a-22eb2ba22234";
             this.TimeoutDelay = 10;  
             this.IsLivenessCheckingEnabled = true;
-            this.ScheduleFile = string.Empty;
-            this.ScheduleTrace = string.Empty;
             this.AdditionalCodeCoverageAssemblies = new Dictionary<string, bool>();
             this.DisableEnvironmentExit = true;
         }


### PR DESCRIPTION
## Fixes
Reference wasn't being used for x10 times, the comment indicated that it was dependent on it. Additionally assigned things in one line as opposed to having multiple lines for the same assignments.

## Type of PR
Refactoring and maintainance

## What's happening now?
No difference

## What's changed?

## Checklist
[] Tested in deployment environment
[] Tested in an alternate environment (please update here: )
[] Major feature added
[] Bux fix
[x] Other (explain: refacoring)

## Additional information

