### PR TITLE
skip mixed-mode assemblies during rewriting

### DIFF
--- a/Source/Test/Rewriting/AssemblyRewriter.cs
+++ b/Source/Test/Rewriting/AssemblyRewriter.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Coyote.Rewriting
             string assemblyName = Path.GetFileName(assemblyPath);
             if (this.RewrittenAssemblies.ContainsKey(Path.GetFileNameWithoutExtension(assemblyPath)))
             {
-                // The assembly is already rewritten.
+                // The assembly is already rewritten, so skip it.
                 return;
             }
 

--- a/Source/Test/Rewriting/AssemblyRewriter.cs
+++ b/Source/Test/Rewriting/AssemblyRewriter.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Coyote.Rewriting
                     this.Log.WriteLine(LogSeverity.Warning, $"..... Skipping assembly (reason: already rewritten by Coyote v{GetAssemblyRewritterVersion()})");
                     return;
                 }
-                else if (!IsAssemblyILOnly(assembly))
+                else if (IsMixedModeAssembly(assembly))
                 {
                     // Mono.Cecil does not support writing mixed-mode assemblies.
                     this.Log.WriteLine(LogSeverity.Warning, $"..... Skipping assembly (reason: rewriting a mixed-mode assembly is not supported)");
@@ -574,21 +574,21 @@ namespace Microsoft.Coyote.Rewriting
         }
 
         /// <summary>
-        /// Checks if the specified assembly only contains IL.
+        /// Checks if the specified assembly is a mixed-mode assembly.
         /// </summary>
         /// <param name="assembly">The assembly to check.</param>
         /// <returns>True if the assembly only contains IL, else false.</returns>
-        private static bool IsAssemblyILOnly(AssemblyDefinition assembly)
+        private static bool IsMixedModeAssembly(AssemblyDefinition assembly)
         {
             foreach (var module in assembly.Modules)
             {
                 if ((module.Attributes & ModuleAttributes.ILOnly) == 0)
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/Source/Test/Rewriting/AssemblyRewriter.cs
+++ b/Source/Test/Rewriting/AssemblyRewriter.cs
@@ -218,6 +218,12 @@ namespace Microsoft.Coyote.Rewriting
                 }
                 catch (Exception ex)
                 {
+                    if (!this.Options.IsReplacingAssemblies)
+                    {
+                        // Make sure to copy the original assembly to avoid any corruptions.
+                        CopyFile(assemblyPath, outputDirectory);
+                    }
+
                     if (ex is AggregateException ae && ae.InnerException != null)
                     {
                         this.Log.WriteLine(LogSeverity.Error, ae.InnerException.Message);
@@ -228,9 +234,6 @@ namespace Microsoft.Coyote.Rewriting
                     }
 
                     errors++;
-
-                    // Make sure to copy the original file to avoid any corruptions due to a rewriting error.
-                    CopyFile(assemblyPath, outputDirectory);
                 }
             }
 


### PR DESCRIPTION
Making skipping mixed-mode assemblies during rewriting more robust. This time we check explicitly, and not piggy back on Mono.Cecil doing this check for us. We also make sure to copy an original assembly to the destination, upon an error, to avoid any rewriting issues.