### PR TITLE
Fix more accessibility bugs

### DIFF
--- a/docs/concepts/actors/state-machines.md
+++ b/docs/concepts/actors/state-machines.md
@@ -150,8 +150,10 @@ using a `RaisePopStateEvent` call:
 ```csharp
 void HandlePing()
 {
-    Console.WriteLine("Server received ping event while in the {0} state", this.CurrentState.Name);
-    this.RaisePopStateEvent();  // pop the current state off the stack of active states.
+    Console.WriteLine("Server received ping event while in the {0} state", 
+        this.CurrentState.Name);
+    // pop the current state off the stack of active states.
+    this.RaisePopStateEvent();  
 }
 ```
 

--- a/docs/concepts/actors/timers.md
+++ b/docs/concepts/actors/timers.md
@@ -83,7 +83,8 @@ private void HandleTimeout(Event e)
     this.WriteMessage("<Client> Handling timeout from timer");
 
     this.WriteMessage("<Client> Starting a period timer");
-    this.PeriodicTimer = this.StartPeriodicTimer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), new CustomTimerEvent());
+    this.PeriodicTimer = this.StartPeriodicTimer(TimeSpan.FromSeconds(1), 
+        TimeSpan.FromSeconds(1), new CustomTimerEvent());
 }
 ```
 

--- a/docs/get-started/using-coyote.md
+++ b/docs/get-started/using-coyote.md
@@ -71,7 +71,8 @@ original build. This can be done using the `--strong-name-key-file` command line
 For example, from your `coyote` repo:
 
 ```plain
-bin\net48\coyote rewrite d:\git\foundry99\Coyote\Tests\Tests.SystematicTesting\bin\net48\rewrite.coyote.json --strong-name-key-file Common\Key.snk
+coyote rewrite d:\git\Coyote\Tests\Tests.SystematicTesting\bin\net48\rewrite.coyote.json
+    --strong-name-key-file Common\Key.snk
 ```
 
 You can also provide this key in the JSON file using the `StrongNameKeyFile` property.

--- a/docs/how-to/coverage.md
+++ b/docs/how-to/coverage.md
@@ -14,19 +14,19 @@ options to report code and activity coverage:
 ```plain
 Code and activity coverage options:
 -----------------------------------
-  -c, --coverage string       : Generate code coverage statistics (via VS instrumentation) with zero
-                                or more values equal to:
-                                 code: Generate code coverage statistics (via VS instrumentation)
-                                 activity: Generate activity (state machine, event, etc.) coverage
-                                statistics
-                                 activity-debug: Print activity coverage statistics with debug info
+  -c, --coverage string       
+        : Generate code coverage statistics (via VS instrumentation) with zero
+          or more values equal to:
+            code: Generate code coverage statistics (via VS instrumentation)
+            activity: Generate activity (state machine, event, etc.) coverage statistics
+            activity-debug: Print activity coverage statistics with debug info
   -instr, --instrument string
-                              : Additional file spec(s) to instrument for code coverage (wildcards
-                                supported)
+        : Additional file spec(s) to instrument for code coverage (wildcards
+          supported)
   -instr-list, --instrument-list string
-                              : File containing the paths to additional file(s) to instrument for
-                                code coverage, one per line, wildcards supported, lines starting
-                                with '//' are skipped
+        : File containing the paths to additional file(s) to instrument for
+          code coverage, one per line, wildcards supported, lines starting
+          with '//' are skipped
 ```
 
 Detailed descriptions are provided in subsequent sections. The following provides a quick overview.

--- a/docs/how-to/unit-testing.md
+++ b/docs/how-to/unit-testing.md
@@ -19,7 +19,8 @@ a complete example using xUnit. The project simply includes xUnit and the Coyote
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; 
+                     buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 </Project>
@@ -103,20 +104,21 @@ And the log file contains the familiar output of `coyote test` as follows:
 ```xml
 <TestLog> Running test.
 <ErrorLog> This test failed!
-<StackTrace>    at Microsoft.Coyote.SystematicTesting.OperationScheduler.NotifyAssertionFailure(String text,
-Boolean killTasks, Boolean cancelExecution)
-   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.Assert(Boolean predicate, String s, Object[] args)
+<StackTrace>
+at Microsoft.Coyote.SystematicTesting.OperationScheduler.NotifyAssertionFailure(
+    String text, Boolean killTasks, Boolean cancelExecution)
+   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.Assert(Boolean predicate, String s)
    at ConsoleApp14.Test.CoyoteTestMethod()
-   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine stateMachine)
+   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine]()
    at ConsoleApp14.Test.CoyoteTestMethod()
-   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.c__DisplayClass21_0.RunTestb__0d.MoveNext()
-   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine stateMachine)
-   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.c__DisplayClass21_0.RunTestb__0()
+   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.RunTestb__0d.MoveNext()
+   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine]()
+   at Microsoft.Coyote.SystematicTesting.ControlledRuntime.RunTestb__0()
    at System.Threading.Tasks.Task.InnerInvoke()
    at System.Threading.Tasks.Task.c.cctorb__274_0(Object obj)
-   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread,
-   ExecutionContext executionContext, ContextCallback callback, Object state)
-   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task currentTaskSlot, Thread threadPoolThread)
+   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(
+       Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback)
+   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task currentTaskSlot)
    at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)
    at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)
    at System.Threading.ThreadPoolWorkQueue.Dispatch()
@@ -128,7 +130,8 @@ Boolean killTasks, Boolean cancelExecution)
 <StrategyLog> Scheduling statistics:
 <StrategyLog> Explored 1 schedule: 1 fair and 0 unfair.
 <StrategyLog> Found 100.00% buggy schedules.
-<StrategyLog> Number of scheduling points in fair terminating schedules: 3 (min), 3 (avg), 3 (max).
+<StrategyLog> Number of scheduling points in fair terminating schedules: 
+              3 (min), 3 (avg), 3 (max).
 ```
 
 The `TestEngine.Create` method has overloads for supporting Coyote test methods with

--- a/docs/samples/actors/failover-robot-navigator.md
+++ b/docs/samples/actors/failover-robot-navigator.md
@@ -265,8 +265,8 @@ Starting TestingProcessScheduler in process 26236
 ..... Iteration #30
 ... Task 0 found a bug.
 ... Emitting task 0 traces:
-..... Writing .\bin\net5.0\Output\DrinksServingRobotActors.exe\CoyoteOutput\DrinksServingRobotActors_0_0.txt
-..... Writing .\bin\net5.0\Output\DrinksServingRobotActors.exe\CoyoteOutput\DrinksServingRobotActors_0_0.schedule
+..... Writing CoyoteOutput\DrinksServingRobotActors_0_0.txt
+..... Writing CoyoteOutput\DrinksServingRobotActors_0_0.schedule
 ... Elapsed 0.5330326 sec.
 ... Testing statistics:
 ..... Found 1 bug.
@@ -283,7 +283,8 @@ pretty big, it contains the test iteration that failed, and towards the end of t
 see something like this:
 
 ```xml
-<ErrorLog> Microsoft.Coyote.Samples.DrinksServingRobot.LivenessMonitor detected liveness bug in hot state 'Busy' at the end of program execution.
+<ErrorLog> Microsoft.Coyote.Samples.DrinksServingRobot.LivenessMonitor detected liveness bug 
+           in hot state 'Busy' at the end of program execution.
 <StrategyLog> Found bug using 'PCT' strategy.
 <StrategyLog> Testing statistics:
 <StrategyLog> Found 1 bug.
@@ -323,7 +324,8 @@ public static class Program
     public static void Execute(IActorRuntime runtime)
     {
         runtime.RegisterMonitor<LivenessMonitor>();
-        ActorId driver = runtime.CreateActor(typeof(FailoverDriver), new FailoverDriver.ConfigEvent(RunForever));
+        ActorId driver = runtime.CreateActor(typeof(FailoverDriver), 
+            new FailoverDriver.ConfigEvent(RunForever));
     }
 }
 ```
@@ -466,7 +468,8 @@ the test.
 Remember the last lines of the coyote test execution log file:
 
 ```shell
-<ErrorLog> Monitor 'Microsoft.Coyote.Samples.DrinksServingRobot.LivenessMonitor' detected liveness bug in hot state 'Busy' at the end of program execution.
+<ErrorLog> Monitor 'Microsoft.Coyote.Samples.DrinksServingRobot.LivenessMonitor' detected 
+liveness bug in hot state 'Busy' at the end of program execution.
 ```
 
 If you add to the coyote test command line `--graph-bug`, and test again:
@@ -478,7 +481,7 @@ coyote test .\bin\net5.0\DrinksServingRobotActors.dll -i 1000 -ms 2000 --sch-pct
 you'll see in the output of the tester that a DGML diagram has been produced:
 
 ```plain
-..... Writing .\bin\net5.0\Output\DrinksServingRobotActors.exe\CoyoteOutput\DrinksServingRobotActors_0_0.dgml
+..... Writing CoyoteOutput\DrinksServingRobotActors_0_0.dgml
 ```
 
 Open this with Visual Studio 2019 and you will see a diagram like this.  Here the diagram is also
@@ -528,14 +531,16 @@ private void NextMove()
         this.WriteLine("<Robot> Reached Client.");
         Specification.Assert(
             this.Coordinates == this.CurrentOrder.ClientDetails.Coordinates,
-            "Having reached the Client the Robot's coordinates must be the same as the Client's, but they aren't");
+            "Having reached the Client the Robot's coordinates must be the same " +
+            "as the Client's, but they aren't");
     }
     else
     {
         var nextDestination = this.Route[0];
         this.Route.RemoveAt(0);
         this.MoveTo(nextDestination);
-        this.Timers["MoveTimer"] = this.StartTimer(TimeSpan.FromSeconds(MoveDuration), new MoveTimerElapsedEvent());
+        this.Timers["MoveTimer"] = this.StartTimer(TimeSpan.FromSeconds(MoveDuration), 
+            new MoveTimerElapsedEvent());
     }
 }
 ```
@@ -618,7 +623,8 @@ private void ReachClient(Event e)
     {
         this.Route = route;
         // this.DrinkOrderPending = false; // this is where it really belongs.
-        this.Timers["MoveTimer"] = this.StartTimer(TimeSpan.FromSeconds(MoveDuration), new MoveTimerElapsedEvent());
+        this.Timers["MoveTimer"] = this.StartTimer(TimeSpan.FromSeconds(MoveDuration), 
+            new MoveTimerElapsedEvent());
     }
 
     this.RaiseGotoStateEvent<MovingOnRoute>();

--- a/docs/samples/actors/failure-detector.md
+++ b/docs/samples/actors/failure-detector.md
@@ -63,7 +63,9 @@ Finding a hard to find bug is one thing, but if you can't reproduce this bug whi
 is no point. So the `*.schedule` can be used with the `coyote replay` command as follows:
 
 ```plain
-coyote replay ./bin/net5.0/Monitors.dll .\bin\net48\Output\Monitors.exe\CoyoteOutput\Monitors_0_0.schedule
+coyote replay ./bin/net5.0/Monitors.dll 
+    .\bin\net48\Output\Monitors.exe\CoyoteOutput\Monitors_0_0.schedule
+    
 . Reproducing trace in coyote-samples\./bin/net48/Monitors.exe
 ... Reproduced 1 bug.
 ... Elapsed 0.1724228 sec.

--- a/docs/tutorials/first-concurrency-unit-test.md
+++ b/docs/tutorials/first-concurrency-unit-test.md
@@ -254,7 +254,7 @@ guaranteed failure is that there are some task interleavings where it passes, an
 fails with the following exception:
 
 ```plain
-Unhandled exception. RowAlreadyExistsException: Exception of type 'RowAlreadyExistsException' was thrown.
+RowAlreadyExistsException: Exception of type 'RowAlreadyExistsException' was thrown.
 ...
 ```
 
@@ -372,7 +372,8 @@ Cool, the flakey test is no longer flakey! Coyote can also help you reproduce an
 simply run `coyote replay` giving the `.schedule` file that Coyote outputs upon finding a bug:
 
 ```plain
-coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule -m TestConcurrentAccountCreation
+coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule 
+    -m TestConcurrentAccountCreation
 . Replaying .\Output\AccountManager.dll\CoyoteOutput\AccountManager_0_1.schedule
 ... Task 0 is using 'replay' strategy.
 ... Reproduced 1 bug (use --break to attach the debugger).
@@ -435,7 +436,8 @@ coyote test .\AccountManager.dll -m TestConcurrentAccountCreation -i 100
 
 If you find a bug you can replay with the following command:
 ```plain
-coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule -m TestConcurrentAccountCreation
+coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule 
+    -m TestConcurrentAccountCreation
 ```
 
 Enjoy!

--- a/docs/tutorials/test-concurrent-operations.md
+++ b/docs/tutorials/test-concurrent-operations.md
@@ -295,7 +295,8 @@ coyote test .\AccountManager.dll -m TestConcurrentAccountDeletion -i 100
 If you find a bug you can replay with the following command (providing the correct .schedule file
 reported from the previous coyote test that failed):
 ```plain
-coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule -m TestConcurrentAccountDeletion
+coyote replay .\AccountManager.dll -schedule AccountManager_0_0.schedule 
+    -m TestConcurrentAccountDeletion
 ```
 
 Feel free to play around with the code and write more concurrency unit tests with Coyote!

--- a/docs/tutorials/testing-aspnet-service.md
+++ b/docs/tutorials/testing-aspnet-service.md
@@ -229,15 +229,15 @@ You will also see that the trace output contains logs such as:
 ```text
 [0HM34OD7O65E5] Creating account with id '0' (name: 'alice', email: 'alice@coyote.com').
 [0HM34OD7O65E5] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
-[0HM34OD7O65E5] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
-[0HM34OD7O65E5] Creating new item with partition key '0' and id '0' in container 'Accounts'
+[0HM34OD7O65E5] Checking if item with partition key '0' and id '0' exists in container 'Accounts'.
+[0HM34OD7O65E5] Creating new item with partition key '0' and id '0' in container 'Accounts'.
 [0HM34OD7O65E7] Storing image with name 'beach' and account id '0'.
 [0HM34OD7O65E6] Deleting account with id '0'.
 [0HM34OD7O65E6] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
 [0HM34OD7O65E7] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
-[0HM34OD7O65E7] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
-[0HM34OD7O65E6] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
-[0HM34OD7O65E6] Deleting item with partition key '0' and id '0' in container 'Accounts'
+[0HM34OD7O65E7] Checking if item with partition key '0' and id '0' exists in container 'Accounts'.
+[0HM34OD7O65E6] Checking if item with partition key '0' and id '0' exists in container 'Accounts'.
+[0HM34OD7O65E6] Deleting item with partition key '0' and id '0' in container 'Accounts'.
 [0HM34OD7O65E7] Creating container 'gallery-0' if it does not exist.
 [0HM34OD7O65E6] Deleting container 'gallery-0' if it exists.
 [0HM34OD7O65E7] Creating blob 'beach' in container 'gallery-0'.

--- a/docs/tutorials/testing-aspnet-service.md
+++ b/docs/tutorials/testing-aspnet-service.md
@@ -225,18 +225,19 @@ and replays it in the VS debugger. To do this, just invoke the command mentioned
 TestConcurrentAccountRequests.schedule ```
 
 You will also see that the trace output contains logs such as:
-```
+
+```text
 [0HM34OD7O65E5] Creating account with id '0' (name: 'alice', email: 'alice@coyote.com').
 [0HM34OD7O65E5] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
-[0HM34OD7O65E5] Checking if item with partition key '0' and id '0' exists in container 'Accounts' of database 'ImageGalleryDB'.
-[0HM34OD7O65E5] Creating new item with partition key '0' and id '0' in container 'Accounts' of database 'ImageGalleryDB'.
+[0HM34OD7O65E5] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
+[0HM34OD7O65E5] Creating new item with partition key '0' and id '0' in container 'Accounts'
 [0HM34OD7O65E7] Storing image with name 'beach' and account id '0'.
 [0HM34OD7O65E6] Deleting account with id '0'.
 [0HM34OD7O65E6] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
 [0HM34OD7O65E7] Creating container 'Accounts' in database 'ImageGalleryDB' if it does not exist.
-[0HM34OD7O65E7] Checking if item with partition key '0' and id '0' exists in container 'Accounts' of database 'ImageGalleryDB'.
-[0HM34OD7O65E6] Checking if item with partition key '0' and id '0' exists in container 'Accounts' of database 'ImageGalleryDB'.
-[0HM34OD7O65E6] Deleting item with partition key '0' and id '0' in container 'Accounts' of database 'ImageGalleryDB'.
+[0HM34OD7O65E7] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
+[0HM34OD7O65E6] Checking if item with partition key '0' and id '0' exists in container 'Accounts'
+[0HM34OD7O65E6] Deleting item with partition key '0' and id '0' in container 'Accounts'
 [0HM34OD7O65E7] Creating container 'gallery-0' if it does not exist.
 [0HM34OD7O65E6] Deleting container 'gallery-0' if it exists.
 [0HM34OD7O65E7] Creating blob 'beach' in container 'gallery-0'.

--- a/docs/windmill_dark/css/highlight.css
+++ b/docs/windmill_dark/css/highlight.css
@@ -41,7 +41,7 @@
 }
 
 .hljs-meta {
-  color: #557182;
+  color: #3EC89E;
 }
 
 .hljs-tag,

--- a/docs/windmill_dark/topbar.html
+++ b/docs/windmill_dark/topbar.html
@@ -21,11 +21,6 @@
       </form>
     </div>
 
-    {# Table-of-contents button #}
-    <div class="wm-top-tool wm-vcenter pull-right wm-small-left">
-      <button id="wm-toc-button" type="button" class="btn btn-sm btn-default wm-vcentered"><i class="fa fa-th-list" aria-hidden="true"></i></button>
-    </div>
-
     {# Optional forward-back buttons #}
     {% if config.extra.history_buttons %}
     <div class="wm-top-tool pull-right wm-vcenter">


### PR DESCRIPTION
Found more bugs using the accessibility tool on all coyote webpages.
See https://www.youtube.com/watch?v=XVvBJoEe4Is

Most of the fixes are about line wrapping sample code so that the tripple tick code blocks do not show horizontal scrollbars, as it turns out those scrollable blocks are not keyboard accessible, for whatever reason.  Fixing the tabindex on those scrollable blocks is not possible because we don't control the markdown generation process.  So the only fix is to manually line wrap code blocks so they never need horizontal scrollbars (which looks nicer anyway).  This is something we should look for in future code reviews.  

One change in colors was required, the C# code meta blocks like [Test] attributes on a method had a color that was too dim, it used to be:
![image](https://user-images.githubusercontent.com/18707114/112381455-d4a5e100-8ca7-11eb-837e-4f929a733964.png)

and this color is different from what C# usually shows.  Most of the time these are type names so I changed the color to show that.  So it now looks like this:

![image](https://user-images.githubusercontent.com/18707114/112381302-ab855080-8ca7-11eb-8352-873fe109afc4.png)

The side effect is that too much is green, including method parameters, but that is not fixable because the markdown syntax parser is not parsing inside meta blocks.  The above OnEventGotoState tag is being parsed as:

```xml
<span class="hljs-meta">OnEventGotoState(typeof(ReadyEvent), typeof(Active))</span>
```
