### PR TITLE
Fix code fence typo in docs/tutorials/actors/hello-world.md

### DIFF
--- a/docs/tutorials/actors/hello-world.md
+++ b/docs/tutorials/actors/hello-world.md
@@ -189,7 +189,7 @@ follows:
  To make this a good test, the `TestActor` keeps track of how many greetings were sent and how many
  were received, and it writes an `Assert` to ensure it doesn't receive too many as follows:
 
- ```csharp
+```csharp
 private void HandleGreeting(Event e)
 {
     // this is perfectly thread safe, because all message handling in actors is

--- a/docs/tutorials/actors/hello-world.md
+++ b/docs/tutorials/actors/hello-world.md
@@ -183,11 +183,11 @@ is declared in a way that tells the `Coyote` runtime it is expecting to receive 
 follows:
 
 ```csharp
- [OnEventDoAction(typeof(GreetingEvent), nameof(HandleGreeting))]
- ```
+[OnEventDoAction(typeof(GreetingEvent), nameof(HandleGreeting))]
+```
 
- To make this a good test, the `TestActor` keeps track of how many greetings were sent and how many
- were received, and it writes an `Assert` to ensure it doesn't receive too many as follows:
+To make this a good test, the `TestActor` keeps track of how many greetings were sent and how many
+were received, and it writes an `Assert` to ensure it doesn't receive too many as follows:
 
 ```csharp
 private void HandleGreeting(Event e)


### PR DESCRIPTION
This resolves a minor typo in a code fence that caused the rendered HTML to be incorrect:
![image](https://user-images.githubusercontent.com/47254805/115615951-94914880-a2bd-11eb-804d-eefc0b2a1044.png)
