### PR TITLE
Resolve extraneous semicolon with em-dash in docs/case-studies/azure-batch-service.md

### DIFF
--- a/docs/case-studies/azure-batch-service.md
+++ b/docs/case-studies/azure-batch-service.md
@@ -27,7 +27,7 @@ microservice be able to:
 
 Coding three of their core microservices with Coyote, the team used Coyote's state machines
 programming model for fully asynchronous, non-blocking computation. The team also wrote
-detailed functional specifications---;as well as models of external services---;to allow for
+detailed functional specifications---as well as models of external services---to allow for
 exhaustive testing of concurrent behaviors and failures. These services totalled to more than
 100,000 lines of code.
 

--- a/docs/case-studies/azure-batch-service.md
+++ b/docs/case-studies/azure-batch-service.md
@@ -10,7 +10,7 @@ of thousands of VMs on Azure.
 
 Integrating scheduling with virtual machine (VM) management, Azure Batch Service supports
 auto-scaling the number of VMs created, spinning up or down according to the needs of the job.
-This differs from many other schedulers---;like Yarn or Mesos, for example---;that must be installed
+This differs from many other schedulers---like Yarn or Mesos, for example---that must be installed
 on a pre-created set of VMs.
 
 ## Challenge


### PR DESCRIPTION
Not certain exactly how `mkdocs` behaves with respect to dashes, but it appears that it takes three dashes to be an em-dash. The semicolons appeared out of place, so they've been removed. The alternate option would be `&mdash;` (rendered on GitHub Markdown as &mdash;) if this doesn't work after publishing.
![image](https://user-images.githubusercontent.com/47254805/115619390-cb695d80-a2c1-11eb-96c1-785bc8353ab8.png)
