### PR TITLE
calculate AssemblyNameScope and provide this information to the passes

### DIFF
--- a/Source/Test/Rewriting/Passes/AssemblyRewriter.cs
+++ b/Source/Test/Rewriting/Passes/AssemblyRewriter.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Coyote.Rewriting
         protected TypeDefinition TypeDef { get; private set; }
 
         /// <summary>
+        /// List of assembly strong names of the assemblies that we are going to rewrite
+        /// so we know what the scope of the rewrite operation is.
+        /// </summary>
+        public HashSet<string> AssemblyNameScope { get; internal set; }
+
+        /// <summary>
         /// The current method being transformed.
         /// </summary>
         protected MethodDefinition Method;

--- a/Tests/Tests.BugFinding/Tasks/TaskInterleavingsTests.cs
+++ b/Tests/Tests.BugFinding/Tasks/TaskInterleavingsTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Coyote.BugFinding.Tests
         [Fact(Timeout = 5000)]
         public void TestInterleavingsWithNestedParallelTasks()
         {
-            this.TestWithError(async () =>
+            this.TestWithError(async (runtime) =>
             {
                 SharedEntry entry = new SharedEntry();
 
@@ -156,9 +156,11 @@ namespace Microsoft.Coyote.BugFinding.Tests
                 {
                     Task task2 = Task.Run(async () =>
                     {
+                        await Task.Delay(runtime.RandomInteger(2));
                         await WriteAsync(entry, 5);
                     });
 
+                    await Task.Delay(runtime.RandomInteger(2));
                     await WriteAsync(entry, 3);
                     await task2;
                 });

--- a/Tests/Tests.Tasks.BugFinding/Join/TaskWaitAnyTests.cs
+++ b/Tests/Tests.Tasks.BugFinding/Join/TaskWaitAnyTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Coyote.Tasks.BugFinding.Tests
                 tcs.SetResult(true);
                 await tcs.Task;
             },
-            configuration: this.GetConfiguration().WithTestingIterations(200));
+            configuration: this.GetConfiguration().WithTestingIterations(500));
         }
 
         private static void AssertCompleted(Task task1, Task task2) =>


### PR DESCRIPTION
This way rewriting method references can be careful not to rewrite methods that are in assemblies that are not being rewritten, instead wrapping any Task objects returned in `InterAssemblyInvocationRewriter`.