### PR TITLE
Updating Console Logger

### DIFF
--- a/Source/Core/IO/Logging/ConsoleLogger.cs
+++ b/Source/Core/IO/Logging/ConsoleLogger.cs
@@ -92,6 +92,13 @@ namespace Microsoft.Coyote.IO
         }
 
         /// <inheritdoc/>
+        public override void Write(string format, params object[] args)
+        {
+            string value = string.Format(format, args);
+            this.Write(LogSeverity.Informational, value);
+        }
+
+        /// <inheritdoc/>
         public override void WriteLine(string format, params object[] args)
         {
             string value = string.Format(format, args);


### PR DESCRIPTION
Creating this PR to update the 'ConsoleLogger.cs' file. The changes made are:

- ~~Removing duplicate code from WriteLine function~~
- Adding an overload variant of 'Write' function for consistency

~~(Note: I rearranged one function due to which the diff is appearing big)~~

Was wondering if there is a way to make log level as an optional parameter to reduce the number of overloads for 'Write' and 'WriteLine' (something like: "public void \<Write or WriteLine\>(string value, LogSeverity severity = LogSeverity.Informational);").