### PR TITLE
Adding Support For Rewriting Concurrent Stacks

### DIFF
--- a/Source/Core/Interception/Collections/Concurrent/ConcurrentCollectionHelper.cs
+++ b/Source/Core/Interception/Collections/Concurrent/ConcurrentCollectionHelper.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Coyote.Runtime;
+
+namespace Microsoft.Coyote.Interception
+{
+    /// <summary>
+    /// Provides methods that are common for all concurrent collections during testing.
+    /// </summary>
+    /// <remarks>This type is intended for concurrent collections only.</remarks>
+    internal class ConcurrentCollectionHelper
+    {
+        internal static void Interleave()
+        {
+            var runtime = CoyoteRuntime.Current;
+            if (runtime.SchedulingPolicy is SchedulingPolicy.Systematic)
+            {
+                runtime.ScheduleNextOperation(AsyncOperationType.Default);
+            }
+            else if (runtime.SchedulingPolicy is SchedulingPolicy.Fuzzing)
+            {
+                runtime.DelayOperation();
+            }
+        }
+    }
+}

--- a/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentDictionary.cs
+++ b/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentDictionary.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Microsoft.Coyote.Runtime;
 
 namespace Microsoft.Coyote.Interception
 {
@@ -28,7 +27,7 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.Count;
         }
 
@@ -44,7 +43,7 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.IsEmpty;
         }
 
@@ -60,7 +59,7 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary[key];
         }
 
@@ -76,7 +75,7 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             concurrentDictionary[key] = value;
         }
 
@@ -92,7 +91,7 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.Keys;
         }
 
@@ -108,21 +107,8 @@ namespace Microsoft.Coyote.Interception
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.Values;
-        }
-
-        private static void Interleave()
-        {
-            var runtime = CoyoteRuntime.Current;
-            if (runtime.SchedulingPolicy is SchedulingPolicy.Systematic)
-            {
-                runtime.ScheduleNextOperation(AsyncOperationType.Default);
-            }
-            else if (runtime.SchedulingPolicy is SchedulingPolicy.Fuzzing)
-            {
-                runtime.DelayOperation();
-            }
         }
 
         /// <summary>
@@ -134,7 +120,7 @@ namespace Microsoft.Coyote.Interception
         public static TValue AddOrUpdate<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, Func<TKey, TValue> addValueFactory,
             Func<TKey, TValue, TValue> updateValueFactory)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.AddOrUpdate(key, addValueFactory, updateValueFactory);
         }
 
@@ -147,7 +133,7 @@ namespace Microsoft.Coyote.Interception
         public static TValue AddOrUpdate<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, TValue addValue,
             Func<TKey, TValue, TValue> updateValueFactory)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.AddOrUpdate(key, addValue, updateValueFactory);
         }
 
@@ -161,7 +147,7 @@ namespace Microsoft.Coyote.Interception
         public static TValue AddOrUpdate<TKey, TArg, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, Func<TKey, TArg, TValue> addValueFactory,
             Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.AddOrUpdate(key, addValueFactory, updateValueFactory, factoryArgument);
         }
 #endif
@@ -172,7 +158,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Clear<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             concurrentDictionary.Clear();
         }
 
@@ -182,7 +168,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ContainsKey<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.ContainsKey(key);
         }
 
@@ -192,7 +178,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.GetEnumerator();
         }
 
@@ -203,7 +189,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TValue GetOrAdd<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, Func<TKey, TValue> valueFactory)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.GetOrAdd(key, valueFactory);
         }
 
@@ -214,7 +200,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TValue GetOrAdd<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, TValue value)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.GetOrAdd(key, value);
         }
 
@@ -227,7 +213,7 @@ namespace Microsoft.Coyote.Interception
         public static TValue GetOrAdd<TKey, TArg, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, Func<TKey, TArg, TValue> valueFactory,
             TArg factoryArgument)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.GetOrAdd(key, valueFactory, factoryArgument);
         }
 #endif
@@ -238,7 +224,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static KeyValuePair<TKey, TValue>[] ToArray<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.ToArray();
         }
 
@@ -248,7 +234,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryAdd<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, TValue value)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.TryAdd(key, value);
         }
 
@@ -258,7 +244,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetValue<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, out TValue value)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.TryGetValue(key, out value);
         }
 
@@ -268,7 +254,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryRemove<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, out TValue value)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.TryRemove(key, out value);
         }
 
@@ -279,7 +265,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryRemove<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, KeyValuePair<TKey, TValue> item)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.TryRemove(item);
         }
 #endif
@@ -290,7 +276,7 @@ namespace Microsoft.Coyote.Interception
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryUpdate<TKey, TValue>(ConcurrentDictionary<TKey, TValue> concurrentDictionary, TKey key, TValue newValue, TValue comparisonValue)
         {
-            Interleave();
+            ConcurrentCollectionHelper.Interleave();
             return concurrentDictionary.TryUpdate(key, newValue, comparisonValue);
         }
     }

--- a/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentQueue.cs
+++ b/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentQueue.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Coyote.Interception
+{
+    /// <summary>
+    /// Provides methods for creating concurrent queues that can be controlled during testing.
+    /// </summary>
+    /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public static class ControlledConcurrentQueue
+    {
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static int get_Count<T>(ConcurrentQueue<T> concurrentQueue)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.Count;
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the <see cref="ConcurrentQueue{T}"/> is empty.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static bool get_IsEmpty<T>(ConcurrentQueue<T> concurrentQueue)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.IsEmpty;
+        }
+
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
+        /// <summary>
+        /// Removes all objects from the <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Clear<T>(ConcurrentQueue<T> concurrentQueue)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentQueue.Clear();
+        }
+#endif
+
+        /// <summary>
+        /// Copies the <see cref="ConcurrentQueue{T}"/> elements to an existing one-dimensional <see cref="Array"/>,
+        /// starting at the specified array index.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo<T>(ConcurrentQueue<T> concurrentQueue, T[] array, int index)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentQueue.CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Adds an object to the end of the <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Enqueue<T>(ConcurrentQueue<T> concurrentQueue, T item)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentQueue.Enqueue(item);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the  <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IEnumerator<T> GetEnumerator<T>(ConcurrentQueue<T> concurrentQueue)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Copies the elements stored in the <see cref="ConcurrentQueue{T}"/> to a new <see cref="Array"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] ToArray<T>(ConcurrentQueue<T> concurrentQueue)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.ToArray();
+        }
+
+        /// <summary>
+        /// Tries to remove and return the object at the beginning of the <see cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryDequeue<T>(ConcurrentQueue<T> concurrentQueue, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.TryDequeue(out result);
+        }
+
+        /// <summary>
+        /// Tries to return an object from the beginning of the <see cref="ConcurrentQueue{T}"/> without removing it.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryPeek<T>(ConcurrentQueue<T> concurrentQueue, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentQueue.TryPeek(out result);
+        }
+    }
+}

--- a/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentStack.cs
+++ b/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentStack.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Coyote.Interception
+{
+    /// <summary>
+    /// Static implementation of the Properties and Methods of <see cref="ConcurrentStack{T}"/> that coyote uses for testing.
+    /// </summary>
+    /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public static class ControlledConcurrentStack
+    {
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static int get_Count<T>(ConcurrentStack<T> concurrentStack)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.Count;
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the <see cref="ConcurrentStack{T}"/> is empty.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static bool get_IsEmpty<T>(ConcurrentStack<T> concurrentStack)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.IsEmpty;
+        }
+
+        /// <summary>
+        /// Removes all objects from the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Clear<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.Clear();
+        }
+
+        /// <summary>
+        /// Copies the <see cref="ConcurrentStack{T}"/> elements to an existing one-dimensional <see cref="Array"/>,
+        /// starting at the specified array index.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo<T>(ConcurrentStack<T> concurrentStack, T[] array, int index)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the  <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IEnumerator<T> GetEnumerator<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Inserts an object at the top of the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Push<T>(ConcurrentStack<T> concurrentStack, T item)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.Push(item);
+        }
+
+        /// <summary>
+        /// Inserts multiple objects at the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void PushRange<T>(ConcurrentStack<T> concurrentStack, T[] items)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.PushRange(items);
+        }
+
+        /// <summary>
+        /// Inserts multiple objects at the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void PushRange<T>(ConcurrentStack<T> concurrentStack, T[] items, int startIndex, int count)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.PushRange(items, startIndex, count);
+        }
+
+        /// <summary>
+        /// Copies the elements stored in the <see cref="ConcurrentStack{T}"/> to a new <see cref="Array"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] ToArray<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.ToArray();
+        }
+
+        /// <summary>
+        /// Attempts to return an object from the top of the <see cref="ConcurrentStack{T}"/> without removing it.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryPeek<T>(ConcurrentStack<T> concurrentStack, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.TryPeek(out result);
+        }
+
+        /// <summary>
+        /// Attempst to pop and return the object at the top of the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryPop<T>(ConcurrentStack<T> concurrentStack, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.TryPop(out result);
+        }
+
+        /// <summary>
+        /// Attempts to pop and return multiple objects from the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TryPopRange<T>(ConcurrentStack<T> concurrenStack, T[] items, int startIndex, int count)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrenStack.TryPopRange(items, startIndex, count);
+        }
+
+        /// <summary>
+        /// Attempts to pop and return multiple objects from the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TryPopRange<T>(ConcurrentStack<T> concurrenStack, T[] items)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrenStack.TryPopRange(items);
+        }
+    }
+}

--- a/Source/Test/Rewriting/CachedNameProvider.cs
+++ b/Source/Test/Rewriting/CachedNameProvider.cs
@@ -51,5 +51,6 @@ namespace Microsoft.Coyote.Rewriting
         internal static string GenericDictionaryFullName { get; } = typeof(SystemGenericCollections.Dictionary<,>).FullName;
 
         internal static string ConcurrentDictonaryFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentDictionary<,>).FullName;
+        internal static string ConcurrentQueueFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentQueue<>).FullName;
     }
 }

--- a/Source/Test/Rewriting/CachedNameProvider.cs
+++ b/Source/Test/Rewriting/CachedNameProvider.cs
@@ -52,5 +52,6 @@ namespace Microsoft.Coyote.Rewriting
 
         internal static string ConcurrentDictonaryFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentDictionary<,>).FullName;
         internal static string ConcurrentQueueFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentQueue<>).FullName;
+        internal static string ConcurrentStackFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentStack<>).FullName;
     }
 }

--- a/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
+++ b/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Coyote.Rewriting
                 {
                     type = this.Module.ImportReference(typeof(ControlledConcurrentQueue));
                 }
+                else if (fullName == CachedNameProvider.ConcurrentStackFullName)
+                {
+                    type = this.Module.ImportReference(typeof(ControlledConcurrentStack));
+                }
             }
 
             return type;

--- a/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
+++ b/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
@@ -89,6 +89,10 @@ namespace Microsoft.Coyote.Rewriting
                 {
                     type = this.Module.ImportReference(typeof(ControlledConcurrentDictionary));
                 }
+                else if (fullName == CachedNameProvider.ConcurrentQueueFullName)
+                {
+                    type = this.Module.ImportReference(typeof(ControlledConcurrentQueue));
+                }
             }
 
             return type;

--- a/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentQueueTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentQueueTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Coyote.Runtime;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrencyFuzzing
+{
+    public class ConcurrentQueueTests : Tests.ConcurrentCollections.ConcurrentQueueTests
+    {
+        public ConcurrentQueueTests(ITestOutputHelper output)
+                : base(output)
+        {
+        }
+
+        private protected override SchedulingPolicy SchedulingPolicy => SchedulingPolicy.Fuzzing;
+
+        protected override Configuration GetConfiguration()
+        {
+            return base.GetConfiguration().WithConcurrencyFuzzingEnabled();
+        }
+    }
+}

--- a/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentStackTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentStackTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Coyote.Runtime;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrencyFuzzing
+{
+    public class ConcurrentStackTests : Tests.ConcurrentCollections.ConcurrentStackTests
+    {
+        public ConcurrentStackTests(ITestOutputHelper output)
+                : base(output)
+        {
+        }
+
+        private protected override SchedulingPolicy SchedulingPolicy => SchedulingPolicy.Fuzzing;
+
+        protected override Configuration GetConfiguration()
+        {
+            return base.GetConfiguration().WithConcurrencyFuzzingEnabled();
+        }
+    }
+}

--- a/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentQueueTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentQueueTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.Coyote.Specifications;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrentCollections
+{
+    public class ConcurrentQueueTests : BaseBugFindingTest
+    {
+        public ConcurrentQueueTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentQueueProperties()
+        {
+            this.Test(() =>
+            {
+                var concurrentQueue = new ConcurrentQueue<int>();
+                Assert.True(concurrentQueue.IsEmpty);
+
+                concurrentQueue.Enqueue(1);
+                var count = concurrentQueue.Count;
+                Assert.Equal(1, count);
+                Assert.Single(concurrentQueue);
+
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
+                concurrentQueue.Clear();
+                Assert.Empty(concurrentQueue);
+#endif
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentQueueMethods()
+        {
+            this.Test(() =>
+            {
+                var concurrentQueue = new ConcurrentQueue<int>();
+                Assert.True(concurrentQueue.IsEmpty);
+
+                concurrentQueue.Enqueue(1);
+                Assert.Single(concurrentQueue);
+
+                bool peekResult = concurrentQueue.TryPeek(out int peek);
+                Assert.True(peekResult);
+                Assert.Equal(1, peek);
+
+                concurrentQueue.Enqueue(2);
+                int[] expectedArray = { 1, 2 };
+                var actualArray = concurrentQueue.ToArray();
+                Assert.Equal(2, concurrentQueue.Count);
+                Assert.Equal(expectedArray, actualArray);
+
+                bool dequeueResult = concurrentQueue.TryDequeue(out int dequeue);
+                Assert.True(dequeueResult);
+                Assert.Equal(1, dequeue);
+                Assert.Single(concurrentQueue);
+
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
+                concurrentQueue.Clear();
+                Assert.Empty(concurrentQueue);
+#endif
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentQueueMethodsWithRaceCondition()
+        {
+            this.TestWithError(() =>
+            {
+                var concurrentQueue = new ConcurrentQueue<int>();
+
+                var t1 = Task.Run(() =>
+                {
+                    concurrentQueue.Enqueue(1);
+                    concurrentQueue.Enqueue(2);
+                    concurrentQueue.TryDequeue(out int value);
+
+                    Specification.Assert(value == 1, "Value is {0} instead of 1.", value);
+                });
+
+                var t2 = Task.Run(() =>
+                {
+                    concurrentQueue.TryDequeue(out int _);
+                });
+
+                Task.WaitAll(t1, t2);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100),
+            expectedError: "Value is 2 instead of 1.",
+            replay: true);
+        }
+    }
+}

--- a/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentQueueTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentQueueTests.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Coyote.BugFinding.Tests.ConcurrentCollections
                 concurrentQueue.Enqueue(1);
                 Assert.Single(concurrentQueue);
 
-                bool peekResult = concurrentQueue.TryPeek(out int peek);
+                bool peekResult = concurrentQueue.TryPeek(out int peekValue);
                 Assert.True(peekResult);
-                Assert.Equal(1, peek);
+                Assert.Equal(1, peekValue);
 
                 concurrentQueue.Enqueue(2);
                 int[] expectedArray = { 1, 2 };
@@ -59,9 +59,9 @@ namespace Microsoft.Coyote.BugFinding.Tests.ConcurrentCollections
                 Assert.Equal(2, concurrentQueue.Count);
                 Assert.Equal(expectedArray, actualArray);
 
-                bool dequeueResult = concurrentQueue.TryDequeue(out int dequeue);
+                bool dequeueResult = concurrentQueue.TryDequeue(out int dequeueValue);
                 Assert.True(dequeueResult);
-                Assert.Equal(1, dequeue);
+                Assert.Equal(1, dequeueValue);
                 Assert.Single(concurrentQueue);
 
 #if !NETSTANDARD2_0 && !NETFRAMEWORK

--- a/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentStackTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentStackTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.Coyote.Specifications;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrentCollections
+{
+    public class ConcurrentStackTests : BaseBugFindingTest
+    {
+        public ConcurrentStackTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackProperties()
+        {
+            this.Test(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+                Assert.True(concurrentStack.IsEmpty);
+
+                concurrentStack.Push(1);
+                var count = concurrentStack.Count;
+                Assert.Equal(1, count);
+                Assert.Single(concurrentStack);
+
+                concurrentStack.Clear();
+                Assert.Empty(concurrentStack);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackMethods()
+        {
+            this.Test(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+                Assert.True(concurrentStack.IsEmpty);
+
+                concurrentStack.Push(1);
+                Assert.Single(concurrentStack);
+
+                bool peekResult = concurrentStack.TryPeek(out int peekValue);
+                Assert.True(peekResult);
+                Assert.Equal(1, peekValue);
+
+                int[] array = { 2, 3 };
+                concurrentStack.PushRange(array);
+                int[] expectedArray = { 3, 2, 1 };
+                var actualArray = concurrentStack.ToArray();
+                Assert.Equal(3, concurrentStack.Count);
+                Assert.Equal(expectedArray, actualArray);
+
+                bool popResult = concurrentStack.TryPop(out int popValue);
+                Assert.True(popResult);
+                Assert.Equal(3, popValue);
+                Assert.Equal(2, concurrentStack.Count);
+
+                concurrentStack.Clear();
+                Assert.Empty(concurrentStack);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackMethodsWithRaceCondition()
+        {
+            this.TestWithError(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+
+                var t1 = Task.Run(() =>
+                {
+                    concurrentStack.Push(1);
+                    concurrentStack.Push(2);
+                    concurrentStack.TryPop(out int value);
+
+                    Specification.Assert(value == 2, "Value is {0} instead of 2.", value);
+                });
+
+                var t2 = Task.Run(() =>
+                {
+                    concurrentStack.TryPop(out int _);
+                });
+
+                Task.WaitAll(t1, t2);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100),
+            expectedError: "Value is 1 instead of 2.",
+            replay: true);
+        }
+    }
+}


### PR DESCRIPTION
Adding support for Coyote to systematically test concurrent stacks in C#.

Changes made:
- Updated the 'ConcurrentCollectionRewriter' to rewrite concurrent stacks in its passes as well
- Refactored common helper function into a new class
- Implemented the static versions of the properties and methods of concurrent stack class
- Added systematic and fuzzing unit test cases to test the controlled concurrent stack implementation