### PR TITLE
Adding Support For Rewriting Concurrent Stacks

### DIFF
--- a/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentStack.cs
+++ b/Source/Core/Interception/Collections/Concurrent/ControlledConcurrentStack.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Coyote.Interception
+{
+    /// <summary>
+    /// Static implementation of the Properties and Methods of <see cref="ConcurrentStack{T}"/> that coyote uses for testing.
+    /// </summary>
+    /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public static class ControlledConcurrentStack
+    {
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static int get_Count<T>(ConcurrentStack<T> concurrentStack)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.Count;
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the <see cref="ConcurrentStack{T}"/> is empty.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+#pragma warning disable IDE1006 // Naming Styles
+        public static bool get_IsEmpty<T>(ConcurrentStack<T> concurrentStack)
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.IsEmpty;
+        }
+
+        /// <summary>
+        /// Removes all objects from the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Clear<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.Clear();
+        }
+
+        /// <summary>
+        /// Copies the <see cref="ConcurrentStack{T}"/> elements to an existing one-dimensional <see cref="Array"/>,
+        /// starting at the specified array index.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo<T>(ConcurrentStack<T> concurrentStack, T[] array, int index)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the  <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IEnumerator<T> GetEnumerator<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Inserts an object at the top of the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Push<T>(ConcurrentStack<T> concurrentStack, T item)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.Push(item);
+        }
+
+        /// <summary>
+        /// Inserts multiple objects at the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void PushRange<T>(ConcurrentStack<T> concurrentStack, T[] items)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.PushRange(items);
+        }
+
+        /// <summary>
+        /// Inserts multiple objects at the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void PushRange<T>(ConcurrentStack<T> concurrentStack, T[] items, int startIndex, int count)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            concurrentStack.PushRange(items, startIndex, count);
+        }
+
+        /// <summary>
+        /// Copies the elements stored in the <see cref="ConcurrentStack{T}"/> to a new <see cref="Array"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] ToArray<T>(ConcurrentStack<T> concurrentStack)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.ToArray();
+        }
+
+        /// <summary>
+        /// Attempts to return an object from the top of the <see cref="ConcurrentStack{T}"/> without removing it.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryPeek<T>(ConcurrentStack<T> concurrentStack, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.TryPeek(out result);
+        }
+
+        /// <summary>
+        /// Attempst to pop and return the object at the top of the <see cref="ConcurrentStack{T}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryPop<T>(ConcurrentStack<T> concurrentStack, out T result)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrentStack.TryPop(out result);
+        }
+
+        /// <summary>
+        /// Attempts to pop and return multiple objects from the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TryPopRange<T>(ConcurrentStack<T> concurrenStack, T[] items, int startIndex, int count)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrenStack.TryPopRange(items, startIndex, count);
+        }
+
+        /// <summary>
+        /// Attempts to pop and return multiple objects from the top of the <see cref="ConcurrentStack{T}"/> atomically.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TryPopRange<T>(ConcurrentStack<T> concurrenStack, T[] items)
+        {
+            ConcurrentCollectionHelper.Interleave();
+            return concurrenStack.TryPopRange(items);
+        }
+    }
+}

--- a/Source/Test/Rewriting/CachedNameProvider.cs
+++ b/Source/Test/Rewriting/CachedNameProvider.cs
@@ -52,5 +52,6 @@ namespace Microsoft.Coyote.Rewriting
 
         internal static string ConcurrentDictonaryFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentDictionary<,>).FullName;
         internal static string ConcurrentQueueFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentQueue<>).FullName;
+        internal static string ConcurrentStackFullName { get; } = typeof(SystemConcurrentCollections.ConcurrentStack<>).FullName;
     }
 }

--- a/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
+++ b/Source/Test/Rewriting/Passes/ConcurrentCollectionRewriter.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Coyote.Rewriting
                 {
                     type = this.Module.ImportReference(typeof(ControlledConcurrentQueue));
                 }
+                else if (fullName == CachedNameProvider.ConcurrentStackFullName)
+                {
+                    type = this.Module.ImportReference(typeof(ControlledConcurrentStack));
+                }
             }
 
             return type;

--- a/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentStackTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrencyFuzzing/Collections/ConcurrentStackTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Coyote.Runtime;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrencyFuzzing
+{
+    public class ConcurrentStackTests : Tests.ConcurrentCollections.ConcurrentStackTests
+    {
+        public ConcurrentStackTests(ITestOutputHelper output)
+                : base(output)
+        {
+        }
+
+        private protected override SchedulingPolicy SchedulingPolicy => SchedulingPolicy.Fuzzing;
+
+        protected override Configuration GetConfiguration()
+        {
+            return base.GetConfiguration().WithConcurrencyFuzzingEnabled();
+        }
+    }
+}

--- a/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentStackTests.cs
+++ b/Tests/Tests.BugFinding/ConcurrentCollections/ConcurrentStackTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.Coyote.Specifications;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Coyote.BugFinding.Tests.ConcurrentCollections
+{
+    public class ConcurrentStackTests : BaseBugFindingTest
+    {
+        public ConcurrentStackTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackProperties()
+        {
+            this.Test(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+                Assert.True(concurrentStack.IsEmpty);
+
+                concurrentStack.Push(1);
+                var count = concurrentStack.Count;
+                Assert.Equal(1, count);
+                Assert.Single(concurrentStack);
+
+                concurrentStack.Clear();
+                Assert.Empty(concurrentStack);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackMethods()
+        {
+            this.Test(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+                Assert.True(concurrentStack.IsEmpty);
+
+                concurrentStack.Push(1);
+                Assert.Single(concurrentStack);
+
+                bool peekResult = concurrentStack.TryPeek(out int peekValue);
+                Assert.True(peekResult);
+                Assert.Equal(1, peekValue);
+
+                int[] array = { 2, 3 };
+                concurrentStack.PushRange(array);
+                int[] expectedArray = { 3, 2, 1 };
+                var actualArray = concurrentStack.ToArray();
+                Assert.Equal(3, concurrentStack.Count);
+                Assert.Equal(expectedArray, actualArray);
+
+                bool popResult = concurrentStack.TryPop(out int popValue);
+                Assert.True(popResult);
+                Assert.Equal(3, popValue);
+                Assert.Equal(2, concurrentStack.Count);
+
+                concurrentStack.Clear();
+                Assert.Empty(concurrentStack);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100));
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestConcurrentStackMethodsWithRaceCondition()
+        {
+            this.TestWithError(() =>
+            {
+                var concurrentStack = new ConcurrentStack<int>();
+
+                var t1 = Task.Run(() =>
+                {
+                    concurrentStack.Push(1);
+                    concurrentStack.Push(2);
+                    concurrentStack.TryPop(out int value);
+
+                    Specification.Assert(value == 2, "Value is {0} instead of 2.", value);
+                });
+
+                var t2 = Task.Run(() =>
+                {
+                    concurrentStack.TryPop(out int _);
+                });
+
+                Task.WaitAll(t1, t2);
+            },
+            configuration: this.GetConfiguration().WithTestingIterations(100),
+            expectedError: "Value is 1 instead of 2.",
+            replay: true);
+        }
+    }
+}


### PR DESCRIPTION
Adding support for Coyote to systematically test concurrent stacks in C#.

Changes made:
- Updated the 'ConcurrentCollectionRewriter' to rewrite concurrent stacks in its passes as well
- Implemented the static versions of the properties and methods of concurrent stack class
- Added systematic and fuzzing unit test cases to test the controlled concurrent stack implementation