### PR TITLE
fix thread renaming

### DIFF
--- a/Tests/Tests.BugFinding/Threads/ThreadRunTests.cs
+++ b/Tests/Tests.BugFinding/Threads/ThreadRunTests.cs
@@ -98,5 +98,23 @@ namespace Microsoft.Coyote.BugFinding.Tests
             },
             configuration: this.GetConfiguration().WithTestingIterations(10));
         }
+
+        [Fact(Timeout = 5000)]
+        public void TestThreadRenamed()
+        {
+            this.Test(() =>
+                {
+                    bool isDone = false;
+                    Thread t = new Thread(() => { isDone = true; });
+                    t.Name = "CustomName";
+                    t.Start();
+                    t.Join();
+
+                    Specification.Assert(isDone, "The expected condition was not satisfied.");
+                    Specification.Assert(t.ThreadState is ThreadState.Stopped, "State of thread '{0}' is {1} instead of Stopped.",
+                        t.ManagedThreadId, t.ThreadState);
+                },
+                configuration: this.GetConfiguration().WithTestingIterations(10));
+        }
     }
 }


### PR DESCRIPTION
Thread renaming is quite common operation. In current implementation thread is distinguished by name and if it's renamed it's not tracked properly. 
I suggest using `ManagedThreadId` instead. If you run the new "TestThreadRenamed" test on old implementation you can reproduce the problem.