### PR TITLE
Reset SynchronizedBlock cache after each iteration

### DIFF
--- a/Source/Test/Rewriting/Types/Threading/Monitor.cs
+++ b/Source/Test/Rewriting/Types/Threading/Monitor.cs
@@ -430,6 +430,13 @@ namespace Microsoft.Coyote.Rewriting.Types.Threading
             }
 
             /// <summary>
+            /// Called to clear out the cache of synchronized blocks in cases where an iteration
+            /// may have been aborted and the cache is no longer valid, and may even hold old
+            /// values that would otherwise not get cleaned up and could impact future iterations.
+            /// </summary>
+            internal static void ResetCache () => Cache.Clear();
+
+            /// <summary>
             /// Creates a new <see cref="SynchronizedBlock"/> for synchronizing access
             /// to the specified object and enters the lock.
             /// </summary>

--- a/Source/Test/SystematicTesting/TestingEngine.cs
+++ b/Source/Test/SystematicTesting/TestingEngine.cs
@@ -21,6 +21,8 @@ using Microsoft.Coyote.Runtime;
 using Microsoft.Coyote.Telemetry;
 using Microsoft.Coyote.Visualization;
 
+using SynchronizedBlock = Microsoft.Coyote.Rewriting.Types.Threading.Monitor.SynchronizedBlock;
+
 namespace Microsoft.Coyote.SystematicTesting
 {
     /// <summary>
@@ -201,6 +203,9 @@ namespace Microsoft.Coyote.SystematicTesting
 
             // Create a client for gathering and sending optional telemetry data.
             TelemetryClient = TelemetryClient.GetOrCreate(this.Configuration, this.LogWriter);
+
+            // Register to clean up the Monitor SynchronizedBlock cache.
+            this.RegisterEndIterationCallBack(_ => SynchronizedBlock.ResetCache());
         }
 
         /// <summary>


### PR DESCRIPTION
When an iteration is stopped due to the maximum step bound being hit, all the controlled threads/operations are abruptly interrupted which can leave orphaned entries in the Monitor.SynchronizedBlock.Cache. When subsequent iterations try to run, they are all guaranteed to fail quickly because they will find instances of SynchronizedBlock in the cache from the previous runtime.

This fix is to make sure the cache is cleared after each iteration run.
